### PR TITLE
Add totalInterestAccumulated to market

### DIFF
--- a/abis/ctoken.json
+++ b/abis/ctoken.json
@@ -309,6 +309,34 @@
     "inputs": [
       {
         "indexed": false,
+        "name": "cashPrior",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "interestAccumulated",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "borrowIndex",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "name": "totalBorrows",
+        "type": "uint256"
+      }
+    ],
+    "name": "AccrueInterest",
+    "type": "event",
+    "signature": "0x4dec04e750ca11537cabcd8a9eab06494de08da3735bc8871cd41250e190bc04"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
         "name": "minter",
         "type": "address"
       },

--- a/schema.graphql
+++ b/schema.graphql
@@ -65,6 +65,12 @@ type Market @entity { # TODO rename to CToken, not market AND ALL OTHERS
     underlyingPriceUSD: BigDecimal!
     "Underlying token decimal length"
     underlyingDecimals: Int!
+
+    # Added to follow interests generation (@Amxx)
+    "Total interest produced by borrowed assets"
+    totalInterestAccumulated: BigDecimal!
+    "Total interest produced by borrowed assets (non decimal value)"
+    totalInterestAccumulatedExact: BigInt!
 }
 
 # Users within the protocol

--- a/src/mappings/comptroller.ts
+++ b/src/mappings/comptroller.ts
@@ -8,7 +8,7 @@ import {
   NewLiquidationIncentive,
   NewMaxAssets,
   NewPriceOracle,
-} from '../types/comptroller/Comptroller'
+} from '../types/Comptroller/Comptroller'
 
 import { Market, Comptroller } from '../types/schema'
 import { mantissaFactorBD, updateCommonCTokenStats } from './helpers'

--- a/src/mappings/ctoken.ts
+++ b/src/mappings/ctoken.ts
@@ -7,6 +7,7 @@ import {
   LiquidateBorrow,
   Transfer,
   AccrueInterest,
+  AccrueInterest1,
   NewReserveFactor,
   NewMarketInterestRateModel,
 } from '../types/cREP/CToken'
@@ -321,6 +322,23 @@ export function handleTransfer(event: Transfer): void {
 }
 
 export function handleAccrueInterest(event: AccrueInterest): void {
+  let market = updateMarket(
+    event.address,
+    event.block.number.toI32(),
+    event.block.timestamp.toI32(),
+  )
+
+  market.totalInterestAccumulatedExact = market.totalInterestAccumulatedExact.plus(
+    event.params.interestAccumulated,
+  )
+  market.totalInterestAccumulated = market.totalInterestAccumulatedExact
+    .toBigDecimal()
+    .div(exponentToBigDecimal(market.underlyingDecimals))
+    .truncate(market.underlyingDecimals)
+  market.save()
+}
+
+export function handleAccrueInterest1(event: AccrueInterest1): void {
   let market = updateMarket(
     event.address,
     event.block.number.toI32(),

--- a/src/mappings/ctoken.ts
+++ b/src/mappings/ctoken.ts
@@ -321,7 +321,20 @@ export function handleTransfer(event: Transfer): void {
 }
 
 export function handleAccrueInterest(event: AccrueInterest): void {
-  updateMarket(event.address, event.block.number.toI32(), event.block.timestamp.toI32())
+  let market = updateMarket(
+    event.address,
+    event.block.number.toI32(),
+    event.block.timestamp.toI32(),
+  )
+
+  market.totalInterestAccumulatedExact = market.totalInterestAccumulatedExact.plus(
+    event.params.interestAccumulated,
+  )
+  market.totalInterestAccumulated = market.totalInterestAccumulatedExact
+    .toBigDecimal()
+    .div(exponentToBigDecimal(market.underlyingDecimals))
+    .truncate(market.underlyingDecimals)
+  market.save()
 }
 
 export function handleNewReserveFactor(event: NewReserveFactor): void {

--- a/src/mappings/markets.ts
+++ b/src/mappings/markets.ts
@@ -159,6 +159,9 @@ export function createMarket(marketAddress: string): Market {
   market.reserveFactor = BigInt.fromI32(0)
   market.underlyingPriceUSD = zeroBD
 
+  market.totalInterestAccumulatedExact = BigInt.fromI32(0)
+  market.totalInterestAccumulated = zeroBD
+
   return market
 }
 

--- a/subgraph.yaml
+++ b/subgraph.yaml
@@ -304,6 +304,8 @@ dataSources:
           handler: handleLiquidateBorrow
         - event: AccrueInterest(uint256,uint256,uint256)
           handler: handleAccrueInterest
+        - event: AccrueInterest(uint256,uint256,uint256,uint256)
+          handler: handleAccrueInterest1
         - event: NewReserveFactor(uint256,uint256)
           handler: handleNewReserveFactor
         - event: Transfer(indexed address,indexed address,uint256)

--- a/yarn.lock
+++ b/yarn.lock
@@ -862,10 +862,10 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-debug@^3.2.6:
-  version "3.2.6"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
-  integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
+debug@=3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
+  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
   dependencies:
     ms "2.0.0"
 


### PR DESCRIPTION
Some users of the compound subgraph have shown interest in tracking interest generated by a market.
Storing both the exact value (bigint) and the bigdecimal decimal representation is necessary to avoid rounding errors during the repeated accumulation

Note: this also fixes an import path